### PR TITLE
Fix duplicated properties in pom.xml

### DIFF
--- a/simple-example/pom.xml
+++ b/simple-example/pom.xml
@@ -12,14 +12,8 @@
 
     <properties>
         <javalite.version>2.5-j8</javalite.version>
-    </properties>
-
-
-
-    <properties>
         <environments>development.test,development</environments>
     </properties>
-
 
     <build>
         <plugins>


### PR DESCRIPTION
Hello @ipolevoy. How are u?

Using this maven/java version:

```bash
~$ mvn --version
Apache Maven 3.8.1 (05c21c65bdfed0f71a2f2ada8b84da59348c4c5d)
Maven home: /Users/peterramaldes/.config/tools/apache-maven-3.8.1
Java version: 13.0.2, vendor: AdoptOpenJDK, runtime: /Library/Java/JavaVirtualMachines/adoptopenjdk-13.jdk/Contents/Home
Default locale: en_BR, platform encoding: UTF-8
OS name: "mac os x", version: "10.16", arch: "x86_64", family: "mac"
```

We received this error:

```bash
simple-example:master$ mvn clean install
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-parseable POM /Users/peterramaldes/repos/github.com/peteraramaldes/javalite-examples/simple-example/pom.xml: Duplicated tag: 'properties' (position: START_TAG seen ...</properties>\n\n\n\n    <properties>... @19:17)  @ line 19, column 17
 @
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project  (/Users/peterramaldes/repos/github.com/peteraramaldes/javalite-examples/simple-example/pom.xml) has 1 error
[ERROR]     Non-parseable POM /Users/peterramaldes/repos/github.com/peteraramaldes/javalite-examples/simple-example/pom.xml: Duplicated tag: 'properties' (position: START_TAG seen ...</properties>\n\n\n\n    <properties>... @19:17)  @ line 19, column 17 -> [Help 2]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/ModelParseException
```

This PR just remove the duplicated properties in pom.xml.
